### PR TITLE
Add dedicated resume page and update portfolio content, styles, and scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Matthew's Portfolio</title>
+  <title>Matthew Smalley | Mechanical Engineering Portfolio</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
@@ -16,6 +16,7 @@
       <button id="menu-btn" class="menu-btn" aria-expanded="false" aria-controls="side-menu">Menu</button>
       <ul id="side-menu" class="nav-links">
         <li><a href="#about">About</a></li>
+        <li><a href="#experience">Experience</a></li>
         <li><a href="#skills">Skills</a></li>
         <li><a href="#projects">Projects</a></li>
         <li><a href="#resume">Resume</a></li>
@@ -23,54 +24,101 @@
     </nav>
 
     <div class="hero-content">
-      <p class="eyebrow">Mechanical Engineer</p>
+      <p class="eyebrow">Engineering Career Applicant</p>
       <h1>Hello, I'm Matthew.</h1>
-      <p class="lead">I design and optimize mechanical systems with a focus on manufacturability, product quality, and practical execution.</p>
-      <a class="btn" href="#projects">View My Work</a>
+      <p class="lead">I apply CAD, 3D printing, SAP/Windchill review, and systematic process improvement to solve real-world aerospace, PCB assembly, and manufacturing challenges.</p>
+      <div class="hero-actions">
+        <a class="btn" href="#projects">View My Work</a>
+        <a class="btn btn-secondary" href="resume.html" target="_blank" rel="noopener">View Resume</a>
+      </div>
     </div>
   </header>
 
   <main>
-    <section id="about" class="card">
-      <h2>My Journey</h2>
-      <p>
-        I’m a mechanical engineering student with hands-on experience in product development, process improvement, and manufacturing support.
-        I enjoy turning concepts into production-ready solutions through practical design, rapid problem solving, and cross-functional collaboration.
-      </p>
+    <section id="about" class="card intro-card">
+      <div>
+        <h2>My Journey</h2>
+        <p>
+          I’m a Northern Illinois University mechanical engineering student in a 4-of-5-year master’s program with a 3.85 GPA, Dean’s List recognition, and engineering internships at Woodward Inc. and Richardson Electronics. I’m motivated and adaptable, with experience developing cost-effective solutions for real-world situations.
+        </p>
+      </div>
+      <ul class="stat-list" aria-label="Resume highlights">
+        <li><strong>3.85</strong><span>GPA</span></li>
+        <li><strong>4/5</strong><span>Year in master’s program</span></li>
+        <li><strong>2026</strong><span>Aerospace operations engineering internship</span></li>
+      </ul>
+    </section>
+
+    <section id="experience" class="card">
+      <h2>Experience Highlights</h2>
+      <div class="timeline">
+        <article>
+          <p class="timeline-date">May 2026 – August 2026</p>
+          <h3>Aerospace Operations Engineering Intern · Woodward Inc.</h3>
+          <p>Optimized PCB surface mount technology processes, applied Creo and 3D printing for SMT machine fixtures, managed engineering reviews in SAP and Windchill, implemented support solutions for military flight control systems and actuation systems, led internal constraint-reduction projects, and reviewed drawings with GD&amp;T.</p>
+        </article>
+        <article>
+          <p class="timeline-date">May 2025 – August 2025</p>
+          <h3>Mechanical Engineering Intern · Richardson Electronics</h3>
+          <p>Optimized circuit board layout design, designed SolidWorks fixtures that improved cycle-time efficiency, worked on lab-machine and process improvements, fixed critical stoppages in circuit board assembly, and programmed select solder machines to improve quality while reducing scrap costs per cycle.</p>
+        </article>
+        <article>
+          <p class="timeline-date">August 2023 – Present</p>
+          <h3>Community Advisor & Desk Assistant · Northern Illinois Housing</h3>
+          <p>Maintained a positive floor environment, communicated with students to settle housing concerns, and worked with housing staff and law enforcement on dispute resolution.</p>
+        </article>
+        <article>
+          <p class="timeline-date">April 2021 – August 2023</p>
+          <h3>Supervisor, Lifeguard & Instructor · Goldfish Swim School</h3>
+          <p>Coordinated action items between management and teaching staff while leading employee teams to improve safety protocols and lesson quality.</p>
+        </article>
+      </div>
     </section>
 
     <section id="skills" class="card">
       <h2>Core Skills</h2>
+      <p>These skills are pulled from my updated resume and grouped around hands-on engineering tools, manufacturing improvements, and cross-functional leadership.</p>
       <ul class="grid-list">
-        <li><button class="chip" onclick="openModal('SolidWorks')">SolidWorks</button></li>
-        <li><button class="chip" onclick="openModal('AutoCAD')">AutoCAD</button></li>
-        <li><button class="chip" onclick="openModal('MATLAB')">MATLAB</button></li>
-        <li><button class="chip" onclick="openModal('Soldering')">Soldering</button></li>
-        <li><button class="chip" onclick="openModal('Product-Design')">Product Design</button></li>
+        <li><button class="chip" onclick="openModal('Creo-SolidWorks')">Creo/SolidWorks</button></li>
+        <li><button class="chip" onclick="openModal('SAP-Windchill')">SAP/Windchill</button></li>
+        <li><button class="chip" onclick="openModal('Printing')">3D Printing</button></li>
+        <li><button class="chip" onclick="openModal('GDT')">Reviewing GD&amp;T</button></li>
+        <li><button class="chip" onclick="openModal('Process-Issues')">Solving Process Issues</button></li>
+        <li><button class="chip" onclick="openModal('Cross-Functional')">Cross-Functional Communication</button></li>
+        <li><button class="chip" onclick="openModal('Engineering-Leadership')">Engineering Team Leadership</button></li>
       </ul>
+      <div class="traits">
+        <span>Responsible</span>
+        <span>Dependable</span>
+        <span>Creative</span>
+        <span>Motivated</span>
+        <span>Empathetic</span>
+        <span>Experienced</span>
+        <span>Teachable</span>
+      </div>
     </section>
 
     <section id="projects" class="card">
       <h2>Projects</h2>
       <ul class="project-list">
-        <li>Selective Solder Machine Carrier</li>
-        <li>Solar Panel Cleaner</li>
-        <li>Custom Modeling for Power Sources</li>
-        <li>Process Improvement and Programming for a PCB Lab</li>
-        <li>Simulating Dynamics of Curved Planes</li>
+        <li><strong>Bionic Hand:</strong> Built a mechanically focused design project that demonstrates practical concept development.</li>
+        <li><strong>Select Solder Carrier for Circuit Boards:</strong> Developed carrier support for repeatable circuit board soldering operations.</li>
+        <li><strong>Inverter Board Manufacturing Process:</strong> Improved manufacturing flow and quality considerations for board assembly.</li>
+        <li><strong>Reflow Oven PCB Fixture:</strong> Designed fixture support for PCB oven workflows.</li>
+        <li><strong>Layout Design for Circuit Board Assemblies:</strong> Optimized circuit board layout design for manufacturability and production support.</li>
       </ul>
     </section>
 
     <section id="resume" class="card">
       <h2>Resume</h2>
-      <p>Review my resume directly below, or download a copy.</p>
+      <p>Review my updated resume directly below, or open the full-page resume.</p>
       <div class="resume-actions">
-        <a href="Matthew%20Smalley%20Resume%20(Website).pdf" target="_blank" rel="noopener" class="btn">Download Resume (PDF)</a>
+        <a href="resume.html" target="_blank" rel="noopener" class="btn">View Updated Resume</a>
       </div>
       <div class="resume-frame-wrap">
         <iframe
           title="Matthew Smalley Resume"
-          src="Matthew%20Smalley%20Resume%20(1).pdf"
+          src="resume.html"
           loading="lazy"
         ></iframe>
       </div>

--- a/resume.html
+++ b/resume.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Matthew Smalley Resume</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body class="resume-page">
+  <main class="resume-sheet">
+    <section class="resume-main">
+      <header class="resume-header">
+        <h1>Matthew Smalley</h1>
+        <p>Engineering Career: Application</p>
+      </header>
+
+      <section>
+        <h2>Experience</h2>
+        <article class="resume-entry">
+          <p class="resume-date">May 2026 – August 2026</p>
+          <h3>Aerospace Operations Engineering Intern · Woodward Inc. (Niles, IL)</h3>
+          <ul>
+            <li>Optimizing surface mount technology processes for PCB assembly.</li>
+            <li>Applying Creo and 3D printing to optimize fixtures for SMT machine handling.</li>
+            <li>Managing engineering review processes within SAP and Windchill.</li>
+            <li>Identifying and implementing solutions supporting military flight control systems and actuation systems.</li>
+            <li>Leading internal projects to eliminate identified constraints.</li>
+            <li>Reading and reviewing drawings with GD&amp;T.</li>
+          </ul>
+        </article>
+        <article class="resume-entry">
+          <p class="resume-date">May 2025 – August 2025</p>
+          <h3>Mechanical Engineering Intern · Richardson Electronics (LaFox, IL)</h3>
+          <ul>
+            <li>Optimizing and creating circuit board layout design.</li>
+            <li>Applying SolidWorks to design fixtures improving cycle-time efficiency.</li>
+            <li>Working with engineers on lab-machine and process improvement.</li>
+            <li>Implementing solutions for fixing critical stoppages in circuit board assembly.</li>
+            <li>Programming select solder machines to improve quality impacting scrap costs per cycle.</li>
+          </ul>
+        </article>
+        <article class="resume-entry">
+          <p class="resume-date">August 2023 – Present</p>
+          <h3>Community Advisor · Northern Illinois Housing (DeKalb, IL)</h3>
+          <ul>
+            <li>Maintaining a positive floor environment while addressing rising issues.</li>
+            <li>Communicating with students to settle housing concerns.</li>
+            <li>Working with housing staff and law enforcement for dispute resolution.</li>
+          </ul>
+        </article>
+        <article class="resume-entry">
+          <p class="resume-date">April 2021 – August 2023</p>
+          <h3>Supervisor/Lifeguard/Instructor · Goldfish Swim School (Glen Ellyn, IL)</h3>
+          <ul>
+            <li>Coordinated action items between management and teaching staff.</li>
+            <li>Led employee teams to improve safety protocols and lesson quality.</li>
+          </ul>
+        </article>
+      </section>
+    </section>
+
+    <aside class="resume-sidebar">
+      <p class="resume-summary">Motivated and adaptable applicant pursuing a career to further develop skills and experience contributing as a team member addressing and developing cost-effective solutions to real-world situations.</p>
+      <section>
+        <h2>Education</h2>
+        <p class="resume-date">August 2023 – Present</p>
+        <h3>Northern Illinois University</h3>
+        <ul>
+          <li>Mechanical Engineering student</li>
+          <li>Year 4 of 5-year Master’s Program</li>
+          <li>GPA: 3.85</li>
+          <li>Dean’s List</li>
+          <li>President for Pi Tau Sigma</li>
+          <li>Treasurer for NIU Jiu-Jitsu Club</li>
+        </ul>
+      </section>
+      <section>
+        <h2>Skills</h2>
+        <ul class="check-list">
+          <li>Creo/SolidWorks</li>
+          <li>SAP/Windchill</li>
+          <li>3D Printing</li>
+          <li>Reviewing GD&amp;T</li>
+          <li>Identifying and Solving Systematic Process Issues</li>
+          <li>Communication in Cross-Functional Teams</li>
+          <li>Leadership in Engineering Teams</li>
+        </ul>
+      </section>
+      <section>
+        <h2>Projects</h2>
+        <ul>
+          <li>Bionic Hand</li>
+          <li>Select Solder Carrier for Circuit Boards</li>
+          <li>Inverter Board Manufacturing Process</li>
+          <li>Reflow Oven PCB Fixture</li>
+          <li>Layout Design for Circuit Board Assemblies</li>
+        </ul>
+      </section>
+      <section>
+        <h2>Contact</h2>
+        <p>2S114 Mayfield Lane<br>Glen Ellyn, IL 60137</p>
+        <p>(630) 287-0914</p>
+        <p>matthewsmalley201@gmail.com</p>
+      </section>
+    </aside>
+  </main>
+</body>
+</html>

--- a/scripts.js
+++ b/scripts.js
@@ -30,11 +30,13 @@ document.querySelectorAll('a[href^="#"]').forEach((anchor) => {
 });
 
 const skillDetails = {
-  SolidWorks: 'Sheet-metal and general modeling, motion studies, and kinematic graph analysis.',
-  AutoCAD: '2D drafting and mechanical layouts for production-ready documentation.',
-  MATLAB: 'Data analysis, script-based automation, and engineering-focused calculations.',
-  Soldering: 'Hand soldering, solder paste application, PCB oven workflows, and troubleshooting.',
-  'Product-Design': 'Part design for in-house manufacturing with practical cost and process awareness.'
+  'Creo-SolidWorks': 'CAD modeling with Creo and SolidWorks for SMT machine fixtures, production tooling, and practical mechanical design support.',
+  'SAP-Windchill': 'Engineering review process experience using SAP and Windchill to manage documentation and support controlled manufacturing changes.',
+  Printing: '3D printing experience used to optimize fixtures for SMT machine handling and accelerate hands-on manufacturing improvements.',
+  GDT: 'Drawing review experience with GD&T, supporting clearer manufacturing requirements and engineering communication.',
+  'Process-Issues': 'Systematic identification and resolution of process issues, including critical stoppages in circuit board assembly and surface mount technology constraints.',
+  'Cross-Functional': 'Communication across engineering teams, manufacturers, housing staff, law enforcement, management, and teaching teams to move issues into action.',
+  'Engineering-Leadership': 'Leadership in engineering teams through internal project ownership, Pi Tau Sigma presidency, and team-focused improvement work.'
 };
 
 function openModal(skillName) {
@@ -43,7 +45,7 @@ function openModal(skillName) {
 
   if (!modalTitle || !modalContent || !skillModal) return;
 
-  modalTitle.textContent = skillName;
+  modalTitle.textContent = skillName.replace(/-/g, ' ');
   modalContent.textContent = skillDetails[skillName] || `Information about ${skillName}.`;
 
   skillModal.classList.add('open');

--- a/styles.css
+++ b/styles.css
@@ -97,6 +97,21 @@ h1 {
   color: #e3ecff;
 }
 
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.btn-secondary {
+  background: rgba(255, 255, 255, 0.14);
+  border: 1px solid rgba(255, 255, 255, 0.45);
+}
+
+.btn-secondary:hover {
+  background: rgba(255, 255, 255, 0.22);
+}
+
 main {
   max-width: 1100px;
   margin: -3rem auto 3rem;
@@ -138,6 +153,67 @@ h2 {
   transform: translateY(-1px);
 }
 
+.intro-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 280px;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.stat-list {
+  display: grid;
+  gap: 0.75rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.stat-list li {
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 1rem;
+}
+
+.stat-list strong {
+  display: block;
+  color: var(--primary);
+  font-size: 1.45rem;
+  line-height: 1;
+}
+
+.stat-list span {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.timeline {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.timeline article {
+  border-left: 4px solid var(--primary);
+  padding-left: 1rem;
+}
+
+.timeline h3 {
+  margin: 0.1rem 0 0.35rem;
+}
+
+.timeline p {
+  margin: 0;
+}
+
+.timeline-date {
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
 .grid-list {
   list-style: none;
   padding: 0;
@@ -159,6 +235,22 @@ h2 {
 
 .chip:hover {
   border-color: #bcc8dc;
+}
+
+.traits {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1.25rem;
+}
+
+.traits span {
+  background: #f8fbff;
+  border: 1px dashed #c7d3e7;
+  border-radius: 999px;
+  color: var(--muted);
+  font-size: 0.86rem;
+  padding: 0.35rem 0.7rem;
 }
 
 .project-list {
@@ -264,5 +356,100 @@ footer {
 
   .hero-content {
     margin-top: 3rem;
+  }
+
+  .intro-card {
+    grid-template-columns: 1fr;
+  }
+}
+
+.resume-page {
+  background: #dfe3ea;
+  padding: 1rem;
+}
+
+.resume-sheet {
+  max-width: 1000px;
+  margin: 0 auto;
+  background: #f7f7f7;
+  border-radius: 0 24px 24px 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(280px, 0.8fr);
+  gap: 2rem;
+  padding: 1.5rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.15);
+}
+
+.resume-sheet h1 {
+  color: #0d0d0d;
+  font-size: clamp(2.25rem, 5vw, 3.2rem);
+}
+
+.resume-header p {
+  font-size: 1.2rem;
+  margin: 0.25rem 0 0;
+}
+
+.resume-sheet h2 {
+  border-bottom: 1px solid #222;
+  padding-bottom: 0.35rem;
+}
+
+.resume-sheet h3,
+.resume-sheet p,
+.resume-sheet li {
+  font-size: 0.92rem;
+}
+
+.resume-entry {
+  margin-bottom: 1.25rem;
+}
+
+.resume-entry h3,
+.resume-sidebar h3 {
+  margin: 0.2rem 0 0.5rem;
+}
+
+.resume-date {
+  color: #1f2937;
+  margin-bottom: 0.2rem;
+}
+
+.resume-sheet ul {
+  margin: 0.5rem 0 0;
+  padding-left: 1rem;
+}
+
+.resume-sheet li {
+  margin-bottom: 0.45rem;
+}
+
+.resume-sidebar {
+  background: #eeeeef;
+  border-radius: 0 24px 24px 0;
+  padding: 1rem 1.25rem;
+}
+
+.resume-summary {
+  margin-top: 0;
+}
+
+.check-list {
+  list-style: none;
+  padding-left: 0 !important;
+}
+
+.check-list li::before {
+  content: '✓';
+  margin-right: 0.75rem;
+}
+
+@media (max-width: 760px) {
+  .resume-sheet {
+    grid-template-columns: 1fr;
+  }
+
+  .resume-sidebar {
+    border-radius: 16px;
   }
 }


### PR DESCRIPTION
### Motivation
- Provide a clean, resume-focused view and surface updated professional content and experience on the portfolio. 
- Improve navigation and call-to-action by exposing the resume as a full-page resource and adding direct resume access from the hero. 
- Clarify skills and experience for hiring audiences by expanding project, skills, and timeline details.

### Description
- Update `index.html` to change the site title, refine the hero copy, add `View Resume` action, expand the `#about` content, add a new `#experience` timeline, update skills chips, and swap the resume iframe and download link to point at `resume.html`.
- Add a new `resume.html` file containing a printable/responsive resume layout with `Experience`, `Education`, `Skills`, `Projects`, and `Contact` sections and matching content from the site. 
- Update `scripts.js` to replace the `skillDetails` mapping with new keys and descriptions (e.g., `Creo-SolidWorks`, `SAP-Windchill`, `Process-Issues`), normalize modal title formatting in `openModal`, and preserve smooth-scrolling/menu behavior. 
- Extend `styles.css` with styles for the hero actions, secondary button, `intro-card` stats, timeline, traits, resume page layout (`.resume-sheet`, `.resume-sidebar`, responsive rules), and other UI refinements.

### Testing
- No automated tests are configured for this repository, so no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e25222c188330a58a3ecaeb812595)