### PR TITLE
Align Experience Highlights with resume using bulleted lists

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,22 +55,42 @@
         <article>
           <p class="timeline-date">May 2026 – August 2026</p>
           <h3>Aerospace Operations Engineering Intern · Woodward Inc.</h3>
-          <p>Optimized PCB surface mount technology processes, applied Creo and 3D printing for SMT machine fixtures, managed engineering reviews in SAP and Windchill, implemented support solutions for military flight control systems and actuation systems, led internal constraint-reduction projects, and reviewed drawings with GD&amp;T.</p>
+          <ul class="experience-list">
+            <li>Optimizing surface mount technology processes for PCB assembly.</li>
+            <li>Applying Creo and 3D printing to optimize fixtures for SMT machine handling.</li>
+            <li>Managing engineering review processes within SAP and Windchill.</li>
+            <li>Identifying and implementing solutions supporting military flight control systems and actuation systems.</li>
+            <li>Leading internal projects to eliminate identified constraints.</li>
+            <li>Reading and reviewing drawings with GD&amp;T.</li>
+          </ul>
         </article>
         <article>
           <p class="timeline-date">May 2025 – August 2025</p>
           <h3>Mechanical Engineering Intern · Richardson Electronics</h3>
-          <p>Optimized circuit board layout design, designed SolidWorks fixtures that improved cycle-time efficiency, worked on lab-machine and process improvements, fixed critical stoppages in circuit board assembly, and programmed select solder machines to improve quality while reducing scrap costs per cycle.</p>
+          <ul class="experience-list">
+            <li>Optimizing and creating circuit board layout design.</li>
+            <li>Applying SolidWorks to design fixtures improving cycle-time efficiency.</li>
+            <li>Working with engineers on lab-machine and process improvement.</li>
+            <li>Implementing solutions for fixing critical stoppages in circuit board assembly.</li>
+            <li>Programming select solder machines to improve quality impacting scrap costs per cycle.</li>
+          </ul>
         </article>
         <article>
           <p class="timeline-date">August 2023 – Present</p>
           <h3>Community Advisor & Desk Assistant · Northern Illinois Housing</h3>
-          <p>Maintained a positive floor environment, communicated with students to settle housing concerns, and worked with housing staff and law enforcement on dispute resolution.</p>
+          <ul class="experience-list">
+            <li>Maintaining a positive floor environment while addressing rising issues.</li>
+            <li>Communicating with students to settle housing concerns.</li>
+            <li>Working with housing staff and law enforcement for dispute resolution.</li>
+          </ul>
         </article>
         <article>
           <p class="timeline-date">April 2021 – August 2023</p>
           <h3>Supervisor, Lifeguard & Instructor · Goldfish Swim School</h3>
-          <p>Coordinated action items between management and teaching staff while leading employee teams to improve safety protocols and lesson quality.</p>
+          <ul class="experience-list">
+            <li>Coordinated action items between management and teaching staff.</li>
+            <li>Led employee teams to improve safety protocols and lesson quality.</li>
+          </ul>
         </article>
       </div>
     </section>

--- a/styles.css
+++ b/styles.css
@@ -206,6 +206,15 @@ h2 {
   margin: 0;
 }
 
+.experience-list {
+  margin: 0.5rem 0 0;
+  padding-left: 1.2rem;
+}
+
+.experience-list li {
+  margin-bottom: 0.35rem;
+}
+
 .timeline-date {
   color: var(--muted);
   font-size: 0.88rem;


### PR DESCRIPTION
### Motivation
- Align the homepage "Experience Highlights" with the on-repo resume (`Resume_Matthew_Smalley (Website)` / `resume.html`) so role entries match the resume's phrasing and improve readability.
- Replace long paragraph summaries with compact bullets to make responsibilities and achievements easier to scan.

### Description
- Replaced paragraph summaries in the `#experience` section of `index.html` with resume-aligned `<ul class="experience-list">` entries for each role. 
- Pulled bullet content from the project's resume (`Resume_Matthew_Smalley (Website)` / `resume.html`) to ensure wording and order match the canonical resume.
- Added `.experience-list` spacing and `li` rules to `styles.css` for consistent spacing and layout within the timeline cards.
- Changes affect the four role entries under `Experience Highlights` on the homepage.

### Testing
- Ran a lightweight HTML parse script (`python` + `html.parser`) against `index.html` and `resume.html`, which completed successfully.
- Ran `git diff --check` to validate whitespace/format issues and found no problems.
- Launched a local static server with `python -m http.server` to verify the site served (server started), but no headless browser was available for screenshots in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e2c484a14833083d82865f75fac63)